### PR TITLE
When watching, continue after error

### DIFF
--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -67,7 +67,6 @@ renderDocument = do
     renderPDF
     copyHere
 
-    event "Complete"
     return (bookfile:files)
 
 
@@ -348,12 +347,13 @@ renderPDF = do
     (exit,out,err) <- execProcess latexmk
     case exit of
         ExitFailure _ ->  do
-            event "Render failed"
             debug "stderr" (intoRope err)
             debug "stdout" (intoRope out)
             write (parseOutputForError tmpdir out)
-            throw exit
-        ExitSuccess -> return ()
+            event "Render failed"
+--          throw exit
+        ExitSuccess -> do
+            event "Completed"
 
 copyHere :: Program Env ()
 copyHere = do


### PR DESCRIPTION
Disable the exception that was thrown if a render fails, allowing `--watch` to setup the inotify watches and cycle again when the user presumably fixes the problem that led to the render failure.

This has the downside that we don't get a non-zero exit code if the render fails in normal operation. To fix that we need the MonadCatch instance for the Program monad to work, currently blocked by https://github.com/oprdyn/unbeliever/pull/6 
