### PR TITLE
Fix render crash

### DIFF
--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -5,13 +5,18 @@ module Environment
 )
 where
 
+import System.Posix.Directory (getWorkingDirectory)
+
 data Env = Env
-    { intermediateFilenamesFrom :: [FilePath]
+    { startingDirectoryFrom :: FilePath
+    , intermediateFilenamesFrom :: [FilePath]
     , masterFilenameFrom :: FilePath
     , resultFilenameFrom :: FilePath
     , tempDirectoryFrom :: FilePath
     }
 
-initial :: Env
-initial = Env [] "" "" ""
+initial :: IO Env
+initial = do
+    cwd <- getWorkingDirectory
+    return (Env cwd [] "/dev/null" "/dev/null" "/dev/null")
 

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -116,7 +116,7 @@ setupTargetFile book = do
     first <- case lookupOptionFlag "default-preamble" params of
         Nothing     -> return []
         Just True   -> do
-            let name = "00_Beginning.tex"
+            let name = "00_Beginning.latex"
             let target = tmpdir ++ "/" ++ name
             liftIO $ withFile target WriteMode $ \handle -> do
                 hWrite handle preamble
@@ -204,7 +204,7 @@ convertMarkdown file =
   in do
     env <- getApplicationState
     let tmpdir = tempDirectoryFrom env
-        file' = replaceExtension file ".tex"
+        file' = replaceExtension file ".latex"
         target = tmpdir ++ "/" ++ file'
         files = intermediateFilenamesFrom env
 
@@ -233,8 +233,7 @@ passthroughLaTeX :: FilePath -> Program Env ()
 passthroughLaTeX file = do
     env <- getApplicationState
     let tmpdir = tempDirectoryFrom env
-        file' = replaceExtension file ".tex"
-        target = tmpdir ++ "/" ++ file'
+        target = tmpdir ++ "/" ++ file
         files = intermediateFilenamesFrom env
 
     ensureDirectory target
@@ -243,7 +242,7 @@ passthroughLaTeX file = do
         liftIO $ do
             copyFileWithMetadata file target
 
-    let env' = env { intermediateFilenamesFrom = file':files }
+    let env' = env { intermediateFilenamesFrom = file:files }
     setApplicationState env'
 
 {-
@@ -304,7 +303,7 @@ produceResult = do
     files' <- case lookupOptionFlag "default-preamble" params of
         Nothing     -> return files
         Just True   -> do
-            let name = "ZZ_Ending.tex"
+            let name = "ZZ_Ending.latex"
             let target = tmpdir ++ "/" ++ name
             liftIO $ withFile target WriteMode $ \handle -> do
                 hWrite handle ending

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -13,7 +13,8 @@ import Environment (initial)
 
 main :: IO ()
 main = do
-    context <- configure (fromPackage version) initial (simple
+    env <- initial
+    context <- configure (fromPackage version) env (simple
         [ Option "default-preamble" (Just 'p') Empty [quote|
             Wrap a built-in default LaTeX preamble (and ending) around your
             supplied source fragments. Most documents will put their own


### PR DESCRIPTION
The problem in #16 turned out to be that a source fragment _Example.latex_ was rendered (and referenced as) _Example.tex_ in tmpdir, but was then being overwritten by the generated intermediate "master" file _Example.tex_ (necessary so we get the desired _Example.pdf_ as result) but which referenced ... _Example.tex_. Loop. Crash.

Resolve by making the extension in tmpdir of converted Markdown fragments to be _.latex_ and preserving the file extension of source LaTeX fragments as _.latex_ as well.

Now the only .tex file in tmpdir is master subsequently fed to **latexmk**.