### PR TITLE
Render intermediate content to a subdirectory in tmpdir

### DIFF
--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -9,6 +9,7 @@ import System.Posix.Directory (getWorkingDirectory)
 
 data Env = Env
     { startingDirectoryFrom :: FilePath
+    , basenameFrom :: String
     , intermediateFilenamesFrom :: [FilePath]
     , masterFilenameFrom :: FilePath
     , resultFilenameFrom :: FilePath
@@ -18,5 +19,5 @@ data Env = Env
 initial :: IO Env
 initial = do
     cwd <- getWorkingDirectory
-    return (Env cwd [] "/dev/null" "/dev/null" "/dev/null")
+    return (Env cwd "None" [] "/dev/null" "/dev/null" "/dev/null")
 

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -100,6 +100,10 @@ extractBookFile params =
 
 setupTargetFile :: FilePath -> Program Env ()
 setupTargetFile book = do
+    env <- getApplicationState
+    let start = startingDirectoryFrom env
+    let dotfile = start ++ "/.target"
+
     tmpdir <- liftIO $ catch
         (do
             dir' <- readFile dotfile
@@ -132,7 +136,6 @@ setupTargetFile book = do
             return [name]
         Just _      -> invalid
 
-    env <- getApplicationState
     let env' = env
             { basenameFrom = base
             , intermediateFilenamesFrom = first
@@ -142,8 +145,6 @@ setupTargetFile book = do
             }
     setApplicationState env'
   where
-    dotfile = ".target"
-
     base = takeBaseName book -- "/directory/file.ext" -> "file"
 
     boom = userError "Temp dir no longer present"


### PR DESCRIPTION
In order to be able to render multiple _.book_ files that share content, we can share a temporary directory, but for that to be safe we need to ensure that fragments of the same name in two different projects don't collide when rendered. Render intermediate forms in a subdirectory named for the basename of the _.book_ file. This would have also fixed #16 as it happens.