### PR TITLE
Share .target file

### DIFF
--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -100,6 +100,10 @@ extractBookFile params =
 
 setupTargetFile :: FilePath -> Program Env ()
 setupTargetFile book = do
+    env <- getApplicationState
+    let start = startingDirectoryFrom env
+    let dotfile = start ++ "/.target"
+
     tmpdir <- liftIO $ catch
         (do
             dir' <- readFile dotfile
@@ -130,7 +134,6 @@ setupTargetFile book = do
             return [name]
         Just _      -> invalid
 
-    env <- getApplicationState
     let env' = env
             { intermediateFilenamesFrom = first
             , masterFilenameFrom = master
@@ -139,8 +142,6 @@ setupTargetFile book = do
             }
     setApplicationState env'
   where
-    dotfile = ".target"
-
     base = takeBaseName book -- "/directory/file.ext" -> "file"
 
     boom = userError "Temp dir no longer present"

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -362,6 +362,7 @@ renderPDF = do
                 , "-interaction=nonstopmode"
                 , "-halt-on-error"
                 , "-file-line-error"
+                , "-cd"
                 , master
                 ]
 


### PR DESCRIPTION
Although we support reading the .book file and the fragments of a document from somewhere else, the final output _.pdf_ is written to _./_. The _.target_ file, indicating the location of the (reusable) temporary directory) should be written here as well.