### PR TITLE
Change use of "default" to "builtin"

### DIFF
--- a/doc/Tutorial.markdown
+++ b/doc/Tutorial.markdown
@@ -75,7 +75,7 @@ Preamble
 --------
 
 The `-p` in the above example was important. It's short for
-`--default-preamble`. Using that option tells the _render_ program to wrap
+`--builtin-preamble`. Using that option tells the _render_ program to wrap
 a simple built-in LaTeX preamble around your document. 
 
 More advanced users will happily use their own LaTeX preamble based on
@@ -92,13 +92,13 @@ ending.latex
 Docker integration
 ------------------
 
-Assuming you _don't_ have years of experience using LaTeX toolchains, you
-can use the default preamble. If you want to install the packages yourself
-you can freely do so. There is also an option to run the render in a
+Assuming you _don't_ have years of experience using LaTeX toolchains, you can
+use a presupplied built-in preamble. If you want to install the packages
+yourself you can freely do so. There is also an option to run the render in a
 Docker container.
 
 ```shell
-$ render --default-preamble --docker=oprdyn/publish-default:latest Trees.book
+$ render --builtin-preamble --docker=oprdyn/publish-builtin:latest Trees.book
 $
 ```
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.2.2
+version:  0.2.3
 synopsis: Publishing tools for papers, books, and presentations
 license: BSD3
 license-file: LICENCE

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -124,7 +124,7 @@ setupTargetFile book = do
         result = tmpdir ++ "/" ++ base ++ ".pdf"
 
     params <- getCommandLine
-    first <- case lookupOptionFlag "default-preamble" params of
+    first <- case lookupOptionFlag "builtin-preamble" params of
         Nothing     -> return []
         Just True   -> do
             let name = "00_Beginning.latex"
@@ -309,7 +309,7 @@ produceResult = do
         files = intermediateFilenamesFrom env
 
     params <- getCommandLine
-    files' <- case lookupOptionFlag "default-preamble" params of
+    files' <- case lookupOptionFlag "builtin-preamble" params of
         Nothing     -> return files
         Just True   -> do
             let name = "ZZ_Ending.latex"

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -15,8 +15,8 @@ main :: IO ()
 main = do
     env <- initial
     context <- configure (fromPackage version) env (simple
-        [ Option "default-preamble" (Just 'p') Empty [quote|
-            Wrap a built-in default LaTeX preamble (and ending) around your
+        [ Option "builtin-preamble" (Just 'p') Empty [quote|
+            Wrap a built-in LaTeX preamble (and ending) around your
             supplied source fragments. Most documents will put their own
             custom preamble as the first fragment in the .book file, but
             for getting started a suitable default can be employed via this


### PR DESCRIPTION
`default` implies "on by default", which is not the case, nor is it something you have to override. Change the name of the option from `--default-preamble` to `--builtin-preamble`.