### PR TITLE
Tool to reflow paragraphs in Markdown documents

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,10 +39,8 @@ executables:
      - Paths_publish
      - Utilities
 
-executables:
   format:
     source-dirs: src
-    main: WrapMain.hs
+    main: FormatMain.hs
     other-modules:
-     - WrapDocument
-     - Paths_publish
+     - FormatDocument

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.2.3
+version:  0.3.1
 synopsis: Publishing tools for papers, books, and presentations
 license: BSD3
 license-file: LICENCE

--- a/package.yaml
+++ b/package.yaml
@@ -18,9 +18,10 @@ dependencies:
  - hinotify
  - pandoc-types
  - pandoc
+ - template-haskell
  - text
  - typed-process
- - unbeliever >= 0.6
+ - unbeliever >= 0.7
  - unix
  - unordered-containers
 

--- a/package.yaml
+++ b/package.yaml
@@ -38,3 +38,11 @@ executables:
      - OutputParser
      - Paths_publish
      - Utilities
+
+executables:
+  format:
+    source-dirs: src
+    main: WrapMain.hs
+    other-modules:
+     - WrapDocument
+     - Paths_publish

--- a/src/FormatDocument.hs
+++ b/src/FormatDocument.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module FormatDocument
+    ( program
+    )
+where
+
+import Core.Program
+import Core.System
+import Core.Text
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import System.Directory (doesFileExist)
+import System.Exit (ExitCode(..))
+import System.IO (withFile, IOMode(WriteMode), hPutStrLn)
+import System.IO.Error (userError, IOError)
+import System.Posix.Temp (mkdtemp)
+import Text.Pandoc (runIOorExplode, readMarkdown, writeMarkdown, def
+    , readerExtensions, pandocExtensions, writerTopLevelDivision
+    , TopLevelDivision(TopLevelChapter))
+
+program :: Program Env ()
+program = do
+    params <- getCommandLine
+
+    event "Identify document fragment"
+
+    file = case lookupArgument "document" params of
+        Nothing -> error "invalid"
+        Just file -> file
+
+
+
+

--- a/src/FormatDocument.hs
+++ b/src/FormatDocument.hs
@@ -21,15 +21,17 @@ import Text.Pandoc (runIOorExplode, readMarkdown, writeMarkdown, def
     , readerExtensions, pandocExtensions, writerTopLevelDivision
     , TopLevelDivision(TopLevelChapter))
 
-program :: Program Env ()
+program :: Program None ()
 program = do
     params <- getCommandLine
 
     event "Identify document fragment"
 
-    file = case lookupArgument "document" params of
-        Nothing -> error "invalid"
-        Just file -> file
+    let file = case lookupArgument "document" params of
+            Nothing -> error "invalid"
+            Just file -> file
+
+    return ()
 
 
 

--- a/src/FormatMain.hs
+++ b/src/FormatMain.hs
@@ -7,7 +7,6 @@ import Core.Program
 import Core.Text
 
 import FormatDocument (program)
-import Paths_publish (version)
 
 
 main :: IO ()

--- a/src/FormatMain.hs
+++ b/src/FormatMain.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main where
+
+import Core.Program
+import Core.Text
+
+import FormatDocument (program)
+import Paths_publish (version)
+
+
+main :: IO ()
+main = do
+    context <- configure (fromPackage version) None (simple
+        [ Argument "document" [quote|
+            The file containing the markdown to be reformatted
+          |]
+        ])
+
+    executeWith context program

--- a/src/FormatMain.hs
+++ b/src/FormatMain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Main where
@@ -8,10 +9,12 @@ import Core.Text
 
 import FormatDocument (program)
 
+version :: Version
+version = $(fromPackage)
 
 main :: IO ()
 main = do
-    context <- configure (fromPackage version) None (simple
+    context <- configure version None (simple
         [ Argument "document" [quote|
             The file containing the markdown to be reformatted
           |]

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -375,7 +375,7 @@ renderPDF = do
             debug "stderr" (intoRope err)
             debug "stdout" (intoRope out)
             write (parseOutputForError tmpdir out)
-            throw exit
+--          throw exit
         ExitSuccess -> return ()
 
 copyHere :: Program Env ()

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -33,7 +33,7 @@ import Environment (Env(..))
 import NotifyChanges (waitForChange)
 import LatexPreamble (preamble, ending)
 import OutputParser (parseOutputForError)
-import Utilities (ensureDirectory, execProcess, ifNewer)
+import Utilities (ensureDirectory, execProcess, ifNewer, isNewer)
 
 program :: Program Env ()
 program = do
@@ -385,9 +385,13 @@ copyHere = do
         start = startingDirectoryFrom env
         final = replaceDirectory result start       -- ie ./Book.pdf
 
-    ifNewer result final $ do
-        event "Copy resultant document to destination"
-        debugS "result" result
-        debugS "final" final
-        liftIO $ do
-            copyFileWithMetadata result final
+    changed <- isNewer result final
+    case changed of
+        True -> do
+            event "Copy resultant PDF to starting directory"
+            debugS "result" result
+            debugS "final" final
+            liftIO $ do
+                copyFileWithMetadata result final
+        False -> do
+            event "Result unchanged"

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Main where
@@ -7,14 +8,15 @@ import Core.Program
 import Core.Text
 
 import RenderDocument (program)
-import Paths_publish (version)
 import Environment (initial)
 
+version :: Version
+version = $(fromPackage)
 
 main :: IO ()
 main = do
     env <- initial
-    context <- configure (fromPackage version) env (simple
+    context <- configure version env (simple
         [ Option "builtin-preamble" (Just 'p') Empty [quote|
             Wrap a built-in LaTeX preamble (and ending) around your
             supplied source fragments. Most documents will put their own

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-12.18
 packages:
- - /home/andrew/src/oprdyn/unbeliever
+ - ../unbeliever
  - .
 
 build:

--- a/symlinks
+++ b/symlinks
@@ -33,5 +33,5 @@ t () {
 
 # main
 e render
-
+e format
 


### PR DESCRIPTION
New executable in the **publish** project, _format_. Takes a fragment formatted with Markdown markup and rewraps any paragraphs into multiple lines suitable for committing. Aims to be a tool suitable for use as a pre-commit hook.