### PR TITLE
Add --temp option

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.4.0
+version:  0.4.1
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/LatexPreamble.hs
+++ b/src/LatexPreamble.hs
@@ -135,6 +135,11 @@ preamble = [quote|
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
 
+\usepackage[normalem]{ulem}
+% avoid problems with \sout in headers with hyperref:
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+
+
 \begin{document}
 |]
 

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -28,6 +28,11 @@ main = do
             Watch all sources listed in the bookfile and re-run the
             rendering engine if changes are detected.
           |]
+        , Option "temp" Nothing (Value "TMPDIR") [quote|
+            The working location for assembling converted fragments and
+            caching intermediate results between runs. By default, a
+            temporary directory will be created in /tmp.
+          |]
         , Option "docker" Nothing (Value "IMAGE") [quote|
             Run the specified Docker image in a container, mount the target
             directory into it as a volume, and do the build there. This allows


### PR DESCRIPTION
Attempt to address weirdness when doing docker-in-docker by offering a `--temp` option to allow user to explicitly specify a temporary directory. This will override (ignore) any value in _.target_.