### PR TITLE
New .book file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.stack-work/
 /tags
 /publish.cabal
+/.vscode
 
 # symlinks to executables
 /render

--- a/doc/Examples.markdown
+++ b/doc/Examples.markdown
@@ -8,7 +8,9 @@ A work with multiple chapters and images in different subdirectories could
 be described as follows
 
 ```
+% publish v2
 preamble.latex
+% begin
 chapters/Introduction.markdown
 chapters/RelatedWork.markdown
 chapters/Results.latex
@@ -16,7 +18,7 @@ chapters/chart-07.svg
 chapters/Analysis.markdown
 chapters/Conclusion.markdown
 generated/References.latex
-ending.latex
+% end
 ```
 
 If you put that list into _EnormousThesis.book_ in the current directory it

--- a/doc/Tutorial.markdown
+++ b/doc/Tutorial.markdown
@@ -27,7 +27,10 @@ to render. Create another file which lists the pieces of your manuscript,
 one per line. Here we've only got one fragment, so this won't take long:
 
 ```text
+% publish v2
+% begin
 Introduction.markdown
+% end
 ```
 
 Put the list into a file named _Trees.book_. The filename extension does
@@ -84,9 +87,12 @@ memoirs. They should put their preamble as the first item in the bookfile,
 perhaps:
 
 ```
+% publish v2
 preamble.latex
+% begin
 Introduction.markdown
 ending.latex
+% end
 ```
 
 Docker integration

--- a/examples/Example.book
+++ b/examples/Example.book
@@ -1,2 +1,5 @@
+% publish v2
+% begin
 Fragment.markdown
 haskell.png
+% end

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.4.4
+version:  0.4.5
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.
@@ -30,6 +30,7 @@ dependencies:
  - directory
  - filepath
  - hinotify
+ - megaparsec
  - pandoc-types
  - pandoc
  - template-haskell

--- a/package.yaml
+++ b/package.yaml
@@ -73,9 +73,12 @@ tests:
      - tests
     main: TestSuite.hs
     other-modules:
+     - CheckBookfileParser
      - CheckTableProperties
      - CompareFragments
+     - Environment
      - FormatDocument
      - PandocToMarkdown
-
+     - ParseBookfile
+ 
 

--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,7 @@ executables:
      - Environment
      - LatexPreamble
      - NotifyChanges
-     - OutputParser
+     - LatexOutputReader
      - PandocToMarkdown
      - RenderDocument
      - Utilities

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.4.5
+version:  2.0.1
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ executables:
      - NotifyChanges
      - LatexOutputReader
      - PandocToMarkdown
+     - ParseBookfile
      - RenderDocument
      - Utilities
 

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -22,7 +22,7 @@ initial = do
     return (Env cwd [] "/dev/null" "/dev/null" "/dev/null")
 
 data Bookfile = Bookfile
-    { bookfileVersionFrom :: Int
-    , bookfilePreamblesFrom :: [FilePath]
-    , bookfileFragmentsFrom :: [FilePath]
+    { versionFrom :: Int
+    , preamblesFrom :: [FilePath]
+    , fragmentsFrom :: [FilePath]
     } deriving (Show, Eq)

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -2,6 +2,7 @@ module Environment
 (
       Env(..)
     , initial
+    , Bookfile(..)
 )
 where
 
@@ -20,3 +21,8 @@ initial = do
     cwd <- getWorkingDirectory
     return (Env cwd [] "/dev/null" "/dev/null" "/dev/null")
 
+data Bookfile = Bookfile
+    { bookfileVersionFrom :: Int
+    , bookfilePreamblesFrom :: [FilePath]
+    , bookfileFragmentsFrom :: [FilePath]
+    } deriving (Show, Eq)

--- a/src/LatexOutputReader.hs
+++ b/src/LatexOutputReader.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module OutputParser
+module LatexOutputReader
     ( parseOutputForError
     )
 where

--- a/src/LatexPreamble.hs
+++ b/src/LatexPreamble.hs
@@ -3,6 +3,7 @@
 
 module LatexPreamble
     ( preamble
+    , beginning
     , ending
     )
 where
@@ -22,8 +23,6 @@ preamble = [quote|
 \setmainfont{Linux Libertine O}
 \setsansfont{TeX Gyre Heros}[Scale=MatchLowercase]
 \setmonofont{Inconsolata}[Scale=MatchLowercase]
-
-%\usepackage[showframe, pass]{geometry}
 
 % use upquote for straight quotes in verbatim environments
 \usepackage{upquote}
@@ -90,6 +89,11 @@ preamble = [quote|
 \setsubsecheadstyle{\normalsize\sffamily\bfseries}
 \setsubsubsecheadstyle{\normalsize\rmfamily\itshape}
 
+|]
+
+beginning :: Rope
+beginning = [quote|
+
 %
 % Output from Skylighting.styleToLaTeX
 %
@@ -135,13 +139,16 @@ preamble = [quote|
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
 
-\usepackage[normalem]{ulem}
+%
 % avoid problems with \sout in headers with hyperref:
-\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+%
 
+\usepackage[normalem]{ulem}
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
 
 \begin{document}
 |]
+
 
 ending :: Rope
 ending = [quote|

--- a/src/ParseBookfile.hs
+++ b/src/ParseBookfile.hs
@@ -54,7 +54,7 @@ parseBookfile = do
     fragments <- many (parseBlank *> parseFileLine <* parseBlank)
     parseEndLine
     return Bookfile
-        { bookfileVersionFrom = version
-        , bookfilePreamblesFrom = preambles
-        , bookfileFragmentsFrom = fragments
+        { versionFrom = version
+        , preamblesFrom = preambles
+        , fragmentsFrom = fragments
         }

--- a/src/ParseBookfile.hs
+++ b/src/ParseBookfile.hs
@@ -16,7 +16,7 @@ data Bookfile = Bookfile
     { bookfileVersion :: Int
     , bookfilePreambles :: [FilePath]
     , bookfileFragments :: [FilePath]
-    } deriving Show
+    } deriving (Show, Eq)
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme (L.space space1 empty empty)
@@ -27,7 +27,8 @@ parseFileLine = do
     file <- takeWhile1P (Just "line containing a filename") (/= '\n')
     return file
 
-__VERSION__ = 0
+__VERSION__ :: Int
+__VERSION__ = 2
 
 parseMagicLine :: Parser Int
 parseMagicLine = do
@@ -43,13 +44,13 @@ parseMagicLine = do
 --  void (many newline) 
 
 parseBeginLine :: Parser ()
-parseBeginLine = dbg "begin" $ try $ label "begin marker" $ do
+parseBeginLine = try $ label "begin marker" $ do
     void (string "% begin")
     void newline
     return ()
 
 parseEndLine :: Parser ()
-parseEndLine = dbg "endin" $ try $ label "end marker" $ do
+parseEndLine = try $ label "end marker" $ do
     void (string "% end")
     void newline
 

--- a/src/ParseBookfile.hs
+++ b/src/ParseBookfile.hs
@@ -1,0 +1,79 @@
+module ParseBookfile where
+
+import Control.Monad
+import Data.Void
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import Text.Megaparsec.Debug
+import qualified Text.Megaparsec.Char.Lexer as L
+
+-- use String, since we need FilePaths which are type aliases over String anyway.
+type Parser = Parsec Void String
+
+-- ParseErrorBundle Text Void
+
+data Bookfile = Bookfile
+    { bookfileVersion :: Int
+    , bookfilePreambles :: [FilePath]
+    , bookfileFragments :: [FilePath]
+    } deriving Show
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme (L.space space1 empty empty)
+
+parseFileLine :: Parser FilePath
+parseFileLine = do
+    notFollowedBy (char '%')
+    file <- takeWhile1P (Just "line containing a filename") (/= '\n')
+    return file
+
+__VERSION__ = 0
+
+parseMagicLine :: Parser Int
+parseMagicLine = do
+    void (char '%') <?> "first line to begin with % character"
+    void spaceChar <?> "a space character"
+    void (string "publish")
+    void spaceChar <?> "a space character"
+    void (char 'v') <?> "the character v and then a number"
+    v <- L.decimal <?> "the bookfile schema version number"
+    unless (v == __VERSION__) (fail ("currently recognized bookfile schema version is v" ++ show __VERSION__))
+    return v
+    
+--  void (many newline) 
+
+parseBeginLine :: Parser ()
+parseBeginLine = dbg "begin" $ try $ label "begin marker" $ do
+    void (string "% begin")
+    void newline
+    return ()
+
+parseEndLine :: Parser ()
+parseEndLine = dbg "endin" $ try $ label "end marker" $ do
+    void (string "% end")
+    void newline
+
+parseBlank :: Parser ()
+parseBlank = do
+    void (hidden (many newline))
+
+
+-- HERE maybe something like
+--
+-- parseBlank <|> parseBegin <|> ...
+--
+-- in any event, the problem is parseFileLine is being overzealous (or is
+-- insufficiently restricted)
+--
+parseBookfile :: Parser Bookfile
+parseBookfile = do
+    version <- parseMagicLine
+    preambles <- many (parseBlank *> parseFileLine <* parseBlank)
+    parseBeginLine
+    fragments <- many (parseBlank *> parseFileLine <* parseBlank)
+    parseEndLine
+    return Bookfile
+        { bookfileVersion = version
+        , bookfilePreambles = preambles
+        , bookfileFragments = fragments
+        }

--- a/src/ParseBookfile.hs
+++ b/src/ParseBookfile.hs
@@ -23,13 +23,13 @@ parseMagicLine = do
     void (char 'v') <?> "the character v and then a number"
     v <- L.decimal <?> "the bookfile schema version number"
     unless (v == __VERSION__) (fail ("currently recognized bookfile schema version is v" ++ show __VERSION__))
+    void newline
     return v
 
 parseBeginLine :: Parser ()
 parseBeginLine = try $ label "begin marker" $ do
     void (string "% begin")
     void newline
-    return ()
 
 parseFileLine :: Parser FilePath
 parseFileLine = do

--- a/src/ParseBookfile.hs
+++ b/src/ParseBookfile.hs
@@ -4,17 +4,12 @@ import Control.Monad
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import Text.Megaparsec.Debug
 import qualified Text.Megaparsec.Char.Lexer as L
+
+import Environment (Bookfile(..))
 
 -- use String, since we need FilePaths which are type aliases over String anyway.
 type Parser = Parsec Void String
-
-data Bookfile = Bookfile
-    { bookfileVersion :: Int
-    , bookfilePreambles :: [FilePath]
-    , bookfileFragments :: [FilePath]
-    } deriving (Show, Eq)
 
 __VERSION__ :: Int
 __VERSION__ = 2
@@ -59,7 +54,7 @@ parseBookfile = do
     fragments <- many (parseBlank *> parseFileLine <* parseBlank)
     parseEndLine
     return Bookfile
-        { bookfileVersion = version
-        , bookfilePreambles = preambles
-        , bookfileFragments = fragments
+        { bookfileVersionFrom = version
+        , bookfilePreamblesFrom = preambles
+        , bookfileFragmentsFrom = fragments
         }

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -32,7 +32,7 @@ import Text.Pandoc (runIOorExplode, readMarkdown, writeLaTeX, def
 import Environment (Env(..))
 import NotifyChanges (waitForChange)
 import LatexPreamble (preamble, ending)
-import OutputParser (parseOutputForError)
+import LatexOutputReader (parseOutputForError)
 import Utilities (ensureDirectory, execProcess, ifNewer, isNewer)
 
 data Mode = Once | Cycle

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -42,10 +42,7 @@ main = do
         , Argument "bookfile" [quote|
             The file containing the list of fragments making up this book.
             If the argument is specified as "Hobbit.book" then "Hobbit"
-            will be used as the basename for the intermediate .latex file
-            and the final output .pdf file. The list file should contain
-            filenames, one per line, of the fragments you wish to render
-            into a complete document.
+            will be used as the basename for the final output .pdf file.
           |]
         ])
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.14
+resolver: lts-13.23
 packages:
  - .
 

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -18,16 +18,16 @@ checkBookfileParser :: Spec
 checkBookfileParser = do
     describe "Parse bookfile format" $ do
         it "Correctly parses a complete first line" $ do
-            parseMaybe parseMagicLine "% publish v2" `shouldBe` Just 2
+            parseMaybe parseMagicLine "% publish v2\n" `shouldBe` Just 2
         it "Errors if first line has incorrect syntax" $ do
-            parseMaybe parseMagicLine "%" `shouldBe` Nothing
-            parseMaybe parseMagicLine "%publish" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish " `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish v" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish  v2" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish v1" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish v2 asdf" `shouldBe` Nothing
+            parseMaybe parseMagicLine "%\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "%publish\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish \n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish  v2\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v1\n" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v2 asdf\n" `shouldBe` Nothing
 
         it "Correctly parses a preamble line" $ do
             parseMaybe parseFileLine "preamble.latex" `shouldBe` Just "preamble.latex"
@@ -43,7 +43,10 @@ two.markdown
             |]
                 `shouldBe` Just (["one.markdown", "two.markdown"] :: [FilePath])
 
-    describe "Complete document" $ do
+        it "Correctly parses a begin end end pragmas" $ do
+            parseMaybe parseBeginLine "% begin\n" `shouldBe` Just ()
+            parseMaybe parseEndLine "% end\n" `shouldBe` Just ()
+
         it "correctly parses a complete bookfile" $ do
             parseMaybe parseBookfile [quote|
 % publish v2
@@ -53,3 +56,12 @@ Introduction.markdown
 Conclusion.markdown
 % end
             |] `shouldBe` Just (Bookfile 2 ["preamble.latex"] ["Introduction.markdown", "Conclusion.markdown"])
+
+        it "correctly parses a complete bookfile with no preamble" $ do
+            parseMaybe parseBookfile [quote|
+% publish v2
+% begin
+Introduction.markdown
+Conclusion.markdown
+% end
+            |] `shouldBe` Just (Bookfile 2 [] ["Introduction.markdown", "Conclusion.markdown"])

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -47,7 +47,7 @@ two.markdown
             parseMaybe parseBeginLine "% begin\n" `shouldBe` Just ()
             parseMaybe parseEndLine "% end\n" `shouldBe` Just ()
 
-        it "correctly parses a complete bookfile" $ do
+        it "Correctly parses a complete bookfile" $ do
             parseMaybe parseBookfile [quote|
 % publish v2
 preamble.latex
@@ -57,7 +57,7 @@ Conclusion.markdown
 % end
             |] `shouldBe` Just (Bookfile 2 ["preamble.latex"] ["Introduction.markdown", "Conclusion.markdown"])
 
-        it "correctly parses a complete bookfile with no preamble" $ do
+        it "Correctly parses a complete bookfile with no preamble" $ do
             parseMaybe parseBookfile [quote|
 % publish v2
 % begin

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -11,6 +11,7 @@ import Core.Text
 import Test.Hspec
 import Text.Megaparsec
 
+import Environment (Bookfile(..))
 import ParseBookfile
 
 checkBookfileParser :: Spec

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -7,7 +7,6 @@ module CheckBookfileParser
     )
 where
 
-import Core.System
 import Core.Text
 import Test.Hspec
 import Text.Megaparsec
@@ -18,16 +17,16 @@ checkBookfileParser :: Spec
 checkBookfileParser = do
     describe "Parse magic line" $ do
         it "correctly parses a complete first line" $ do
-            parseMaybe parseMagicLine "% publish v0" `shouldBe` Just 0
+            parseMaybe parseMagicLine "% publish v2" `shouldBe` Just 2
         it "errors if missing syntax" $ do
             parseMaybe parseMagicLine "%" `shouldBe` Nothing
             parseMaybe parseMagicLine "%publish" `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish" `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish " `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish v" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish  v0" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish  v2" `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish v1" `shouldBe` Nothing
-            parseMaybe parseMagicLine "% publish v0 asdf" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v2 asdf" `shouldBe` Nothing
 
     describe "Parse fragment lines" $ do
         it "correctly parses a preamble line" $ do
@@ -43,3 +42,14 @@ one.markdown
 two.markdown
             |]
                 `shouldBe` Just (["one.markdown", "two.markdown"] :: [FilePath])
+
+    describe "Complete document" $ do
+        it "correctly parses a complete bookfile" $ do
+            parseMaybe parseBookfile [quote|
+% publish v2
+preamble.latex
+% begin
+Introduction.markdown
+Conclusion.markdown
+% end
+            |] `shouldBe` Just (Bookfile 2 ["preamble.latex"] ["Introduction.markdown", "Conclusion.markdown"])

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module CheckBookfileParser
+    ( checkBookfileParser
+    )
+where
+
+import Core.System
+import Core.Text
+import Test.Hspec
+import Text.Megaparsec
+
+import ParseBookfile
+
+checkBookfileParser :: Spec
+checkBookfileParser = do
+    describe "Parse magic line" $ do
+        it "correctly parses a complete first line" $ do
+            parseMaybe parseMagicLine "% publish v0" `shouldBe` Just 0
+        it "errors if missing syntax" $ do
+            parseMaybe parseMagicLine "%" `shouldBe` Nothing
+            parseMaybe parseMagicLine "%publish" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish " `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish  v0" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v1" `shouldBe` Nothing
+            parseMaybe parseMagicLine "% publish v0 asdf" `shouldBe` Nothing
+
+    describe "Parse fragment lines" $ do
+        it "correctly parses a preamble line" $ do
+            parseMaybe parseFileLine "preamble.latex" `shouldBe` Just "preamble.latex"
+        it "parses two filenames in a list" $ do
+            parseMaybe (many (parseFileLine <* parseBlank)) "one.markdown\ntwo.markdown"
+                `shouldBe` Just (["one.markdown", "two.markdown"] :: [FilePath])
+
+        it "parses two filenames with a blank line between them" $ do
+            parseMaybe (many (parseFileLine <* parseBlank)) [quote|
+one.markdown
+
+two.markdown
+            |]
+                `shouldBe` Just (["one.markdown", "two.markdown"] :: [FilePath])

--- a/tests/CheckBookfileParser.hs
+++ b/tests/CheckBookfileParser.hs
@@ -16,10 +16,10 @@ import ParseBookfile
 
 checkBookfileParser :: Spec
 checkBookfileParser = do
-    describe "Parse magic line" $ do
-        it "correctly parses a complete first line" $ do
+    describe "Parse bookfile format" $ do
+        it "Correctly parses a complete first line" $ do
             parseMaybe parseMagicLine "% publish v2" `shouldBe` Just 2
-        it "errors if missing syntax" $ do
+        it "Errors if first line has incorrect syntax" $ do
             parseMaybe parseMagicLine "%" `shouldBe` Nothing
             parseMaybe parseMagicLine "%publish" `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish" `shouldBe` Nothing
@@ -29,14 +29,13 @@ checkBookfileParser = do
             parseMaybe parseMagicLine "% publish v1" `shouldBe` Nothing
             parseMaybe parseMagicLine "% publish v2 asdf" `shouldBe` Nothing
 
-    describe "Parse fragment lines" $ do
-        it "correctly parses a preamble line" $ do
+        it "Correctly parses a preamble line" $ do
             parseMaybe parseFileLine "preamble.latex" `shouldBe` Just "preamble.latex"
-        it "parses two filenames in a list" $ do
+        it "Parses two filenames in a list" $ do
             parseMaybe (many (parseFileLine <* parseBlank)) "one.markdown\ntwo.markdown"
                 `shouldBe` Just (["one.markdown", "two.markdown"] :: [FilePath])
 
-        it "parses two filenames with a blank line between them" $ do
+        it "Parses two filenames with a blank line between them" $ do
             parseMaybe (many (parseFileLine <* parseBlank)) [quote|
 one.markdown
 

--- a/tests/CheckTableProperties.hs
+++ b/tests/CheckTableProperties.hs
@@ -120,7 +120,7 @@ First                   Second                  Third
 -----------------------------------------------------------------------
             |]
 
-        it "a minimal complete example reformats properly" $
+        it "A minimal complete example reformats properly" $
           let
             table = [quote|
 | First | Second | Third |

--- a/tests/Example.book
+++ b/tests/Example.book
@@ -1,0 +1,11 @@
+% publish v2
+preamble.latex
+% begin
+Introduction.markdown
+RelatedWork.markdown
+Results.latex
+chart-07.svg
+Analysis.markdown
+Conclusion.markdown
+References.latex
+% end

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -2,8 +2,9 @@
 
 import Test.Hspec
 
-import Core.System
+import CheckBookfileParser
 import CheckTableProperties
+import Core.System
 import CompareFragments
 
 main :: IO ()
@@ -14,3 +15,4 @@ suite :: Spec
 suite = do
     checkTableProperties
     checkByComparingFragments
+    checkBookfileParser


### PR DESCRIPTION
In order to have a hook to insert required LaTeX elements into rendered document, change the .book file format to include a marker where the `\begin{document}` should be emitted, allowing us to prepend other commands.

This is version 2 of the .book file format, and the major API version of the package has been bumped accordingly.

Closes #28 