### PR TITLE
Change Level 1 to emit \section rather than \chapter

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  2.0.2
+version: 2.0.3
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -28,7 +28,7 @@ import System.Posix.User (getEffectiveUserID, getEffectiveGroupID)
 import Text.Megaparsec (runParser, errorBundlePretty)
 import Text.Pandoc (runIOorExplode, readMarkdown, writeLaTeX, def
     , readerExtensions, readerColumns, pandocExtensions
-    , writerTopLevelDivision, TopLevelDivision(TopLevelChapter))
+    , writerTopLevelDivision, TopLevelDivision(TopLevelSection))
 
 import Environment (Env(..), Bookfile(..))
 import NotifyChanges (waitForChange)
@@ -330,7 +330,7 @@ convertMarkdown file =
         }
 
     writingOptions = def
-        { writerTopLevelDivision = TopLevelChapter
+        { writerTopLevelDivision = TopLevelSection
         }
 
   in do


### PR DESCRIPTION
Facilitate experimentation with the impact of changing level 1 headers from chapter to section.

Would close #42