### PR TITLE
Fix error handling if SVG conversion fails

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.0
+version: 2.1.1
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -405,6 +405,7 @@ convertImage file = do
                 event "Image processing failed"
                 debug "stderr" (intoRope err)
                 debug "stdout" (intoRope out)
+                write ("error: Unable to convert " <> intoRope file <> " from SVG to PDF")
                 throw exit
             ExitSuccess -> return ()
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.14
+resolver: lts-14.16
 packages:
  - .
 


### PR DESCRIPTION
Resolves problems of empty files being written (and subsequently being taken as correctly converted files) if image conversion fails, and not failing silently when that happens.