### PR TITLE
Upgrade to lts-15.0 and GHC 8.8.2

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,1 +1,1 @@
-cradle: {stack: {component: "publish:exe:format" }}
+cradle: {stack: {component: "publish:test:check" }}

--- a/src/PandocToMarkdown.hs
+++ b/src/PandocToMarkdown.hs
@@ -21,8 +21,6 @@ import Core.Text
 import Core.System.Base
 import Data.Foldable (foldl')
 import Data.List (intersperse)
-import Data.Monoid (Monoid(..))
-import Data.Semigroup (Semigroup(..))
 import qualified Data.Text as T (Text, null)
 import GHC.Generics (Generic)
 import Text.Pandoc (Pandoc(..), Block(..), Inline(..), Attr, Format(..)

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -20,8 +20,7 @@ import System.Directory (doesFileExist, doesDirectoryExist
 import System.Exit (ExitCode(..))
 import System.FilePath.Posix (takeBaseName, takeExtension
     , replaceExtension, splitFileName, replaceDirectory)
-import System.IO (withFile, IOMode(WriteMode), hPutStrLn)
-import System.IO.Error (userError, IOError)
+import System.IO (hPutStrLn)
 import System.Posix.Directory (changeWorkingDirectory)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.User (getEffectiveUserID, getEffectiveGroupID)

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE CPP #-}
 
 module Main where
 
@@ -11,7 +12,11 @@ import RenderDocument (program)
 import Environment (initial)
 
 version :: Version
+#ifdef __GHCIDE__
+version = "0"
+#else
 version = $(fromPackage)
+#endif
 
 main :: IO ()
 main = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,3 @@
-resolver: lts-14.19
+resolver: lts-15.0
 packages:
  - .
-
-extra-deps:
- - core-text-0.2.2.6
- - core-data-0.2.1.3
- - core-program-0.2.3.0
-


### PR DESCRIPTION
Includes bump in **pandoc** to 2.9; at 2.8 they changed the internal types from String to Text. Adjust accordingly.